### PR TITLE
Increment `numOfRequests` metric if ssh connection is alive

### DIFF
--- a/pkg/common/helpers.go
+++ b/pkg/common/helpers.go
@@ -15,6 +15,12 @@
 
 package common
 
+import (
+	"os"
+
+	"github.com/nuclio/errors"
+)
+
 func StringInSlice(s string, slice []string) bool {
 	for _, str := range slice {
 		if str == s {
@@ -22,4 +28,18 @@ func StringInSlice(s string, slice []string) bool {
 		}
 	}
 	return false
+}
+
+// FileExists returns true if the given file exists
+func FileExists(filePath string) (bool, error) {
+	_, err := os.Stat(filePath)
+	if err == nil {
+		return true, nil
+
+	} else if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+
+	// sanity: file may or may not exist
+	return false, err
 }

--- a/pkg/sidecarproxy/metricshandler/types.go
+++ b/pkg/sidecarproxy/metricshandler/types.go
@@ -26,3 +26,8 @@ const (
 	NumOfRequestsMetricName         MetricName = "num_of_requests"
 	JupyterKernelBusynessMetricName MetricName = "jupyter_kernel_busyness"
 )
+
+const (
+	OpenSSHConnectionFilePath = "/intercontainer/opensshconnection"
+	SSHConnectionIsAlive      = "1"
+)


### PR DESCRIPTION
In a background loop that runs forever, use the container shared volume to check if jupyter's ssh connection is alive.
If it is - increment the `numOfRequests` metric, so the service won't be scaled to zero.

Tested in a live environment.

Implements https://jira.iguazeng.com/browse/IG-21529